### PR TITLE
Add fallback locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ import App from './App.vue';
 
 const i18n = createI18n({
     locale: 'en',
+    fallbackLocale: 'en',
     messages: {
         'en': {
             home: 'Home'
@@ -33,6 +34,7 @@ export default {
         const i18n = useI18n()
         i18n.createI18n({
             locale: 'en',
+            fallbackLocale: 'en',
             messages: {
                 'en': {
                     home: 'Home'

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,10 @@ import { vueI18nKey } from './injectionSymbols'
  * @param options - {@link I18nOptions}
  */
 export function createI18n(options?: I18nOptions): I18n {
-  const initOptions = Object.assign({ locale: 'en', messages: {} }, options)
+  const initOptions = Object.assign(
+    { locale: 'en', fallbackLocale: 'en', messages: {} },
+    options
+  )
   const current = ref(initOptions.locale)
   const locales: I18nLocales = initOptions.messages
 
@@ -33,11 +36,10 @@ export function createI18n(options?: I18nOptions): I18n {
 
       const locale =
         typeof option === 'string' && option ? option : current.value
-      if (!locales[locale]) {
-        return key
-      }
 
-      let message = getMessage(locales[locale], key)
+      let message =
+        getMessage(locales[locale], key) ||
+        getMessage(locales[initOptions.fallbackLocale], key)
       if (option && typeof option !== 'string') {
         const values = parseLocaleValues(message, option)
         if (!isEmpty(values)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ import { DeepReadonly, UnwrapNestedRefs } from '@vue/reactivity'
  */
 export type I18nOptions = {
   locale?: string
+  fallbackLocale?: string
   messages?: I18nLocales
 }
 


### PR DESCRIPTION
Add the `fallbackLocale` option to use whenever messages in current locale are unavailable.